### PR TITLE
Fix tag balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,36 @@ var input = '...';
 var result = purifier.purify(input);
 ```
 
+## Advanced Usage
+
+The following outlines the configuration that is secure by default. You should perform due dilligence to confirm your use cases are safe before disabling or altering the configurations.
+
+```js
+// The default configuration
+new Purifier({
+	whitelistTags: ['a', '...'],
+	whitelistAttributes: ['href', '...'],
+	enableCanonicalization: true,
+	tagBalance: {
+		enabled: true,
+		stackSize: 100
+	}
+});
+```
+
+<!--
+#### whitelistTags
+
+#### whitelistAttributes
+
+#### enableCanonicalization
+-->
+
+#### tagBalance
+The untrusted data must be self-contained. Hence, it cannot close any tags prior to its inclusion, nor leave any of its own tags unclosed. An efficient and simple tag balancing algorithm is applied by default to enforce this goal only, and may not produce perfectly nested output. You may implement another tag balancing algorithm before invoking purify. But the default one should still be enabled, unless you're sure the self-contained requirement is met.
+
+The ``stackSize`` (default: 100) is a limit imposed on the maximum number of unclosed tags (or the max levels of nested tags). When an untrusted data attempts to open tags that are so nested and has exceeded the allowed limit, the algorithm will cease any further processing but simply close all of those tags.
+
 ## Development
 
 ### How to build

--- a/src/html-purify.js
+++ b/src/html-purify.js
@@ -11,7 +11,7 @@ See the accompanying LICENSE file for terms.
         derivedState = require('./derived-states.js'),
         xssFilters = require('xss-filters'),
         CssParser = require('css-js'),
-        hrefAttribtues = tagAttList.HrefAttributes,
+        hrefAttributes = tagAttList.HrefAttributes,
         voidElements = tagAttList.VoidElements;
 
     function Purifier(config) {
@@ -116,7 +116,7 @@ See the accompanying LICENSE file for terms.
 
                             attrValString += ' ' + key;
                             if (value !== null) {
-                                attrValString += '="' + (hrefAttribtues[key] ? xssFilters.uriInDoubleQuotedAttr(decodeURI(value)) : value) + '"';
+                                attrValString += '="' + (hrefAttributes[key] ? xssFilters.uriInDoubleQuotedAttr(decodeURI(value)) : value) + '"';
                             }
                         }
                     }

--- a/src/tag-attr-list.js
+++ b/src/tag-attr-list.js
@@ -261,3 +261,6 @@ exports.HrefAttributes = {
 // Void elements only have a start tag; end tags must not be specified for void elements.
 // https://html.spec.whatwg.org/multipage/syntax.html#void-elements
 exports.VoidElements = {"area":1, "base":1, "br":1, "col":1, "embed":1, "hr":1, "img":1, "input":1, "keygen":1, "link":1, "menuitem":1, "meta":1, "param":1, "source":1, "track":1, "wbr":1};
+
+// https://html.spec.whatwg.org/multipage/syntax.html#optional-tags
+exports.OptionalElements = {/*"plaintext":1, "html":1, "head":1, "body":1,*/ "li":1, "dt":1, "dd":1, "p":1, "rt":1, "rp":1, "optgroup":1, "option":1, "colgroup":1, "caption":1, "thead":1, "tbody":1, "tfoot":1, "tr":1, "td":1, "th":1};

--- a/tests/test-vectors.js
+++ b/tests/test-vectors.js
@@ -628,12 +628,12 @@ var generalVectors = [
 {
 	id: 10,
 	input: "<table><tr bz/></table>normal tag made standalone with bogus trunc attr",
-	output: "<table><tr /></table>normal tag made standalone with bogus trunc attr"
+	output: "<table><tr></table>normal tag made standalone with bogus trunc attr"
 },
 {
 	id: 11,
 	input: "<table><tr color/></table>normal tag made standalone with trunc attr bad val",
-	output: "<table><tr /></table>normal tag made standalone with trunc attr bad val"
+	output: "<table><tr></table>normal tag made standalone with trunc attr bad val"
 },
 {
 	id: 12,
@@ -648,7 +648,7 @@ var generalVectors = [
 {
 	id: 14,
 	input: "<table><tr size=\"4\"/></table>normal tag made standalone with value",
-	output: "<table><tr size=\"4\" /></table>normal tag made standalone with value"
+	output: "<table><tr size=\"4\"></table>normal tag made standalone with value"
 },
 //style attribute tests
 {
@@ -779,7 +779,7 @@ var generalVectors = [
 {
 	id: 40,
 	input: "<option selected />",
-	output: "<option selected />"
+	output: "<option selected>"
 },
 {
 	id: 41,
@@ -799,7 +799,7 @@ var generalVectors = [
 {
 	id: 44,
 	input: "<option selected/>",
-	output: "<option selected />"
+	output: "<option selected>"
 },
 {
 	id: 45,
@@ -831,7 +831,17 @@ var generalVectors = [
 	id: 50,
 	input: "abc <!-- 123",
 	output: "abc "
-}
+},
+{
+	id: 51,
+	input: "<a href=\"http://www.yahoo.com/\" />hello",
+	output: "<a href=\"http://www.yahoo.com/\">hello</a>"
+},
+// {
+// 	id: 52,
+// 	input: "<img src=\"x\" id=\'\" onerror=\"alert(1)\' />",
+// 	output: "<img src=\"x\" id=\'\" onerror=\"alert(1)\' />"
+// }
 ];
 
 exports.html5secVectors = html5secVectors;

--- a/tests/unit/html-purify.js
+++ b/tests/unit/html-purify.js
@@ -35,12 +35,12 @@ Authors: Aditya Mahendrakar <maditya@yahoo-inc.com>
             var html = "</div>foo</h2>bar<a href=\"123\">hello<b>world</a><embed>123</embed><br /><br/><p>";
 
             // with tag balancing enabled by default
-            var output = (new Purifier()).purify(html);
-            assert.equal(output, 'foobar<a href=\"123\">hello<b>world</b></a><embed />123<br /><br /><p></p>');
+            var output = (new Purifier({enableTagBalancing:true})).purify(html);
+            assert.equal(output, 'foobar<a href="123">hello<b>world</a><embed />123<br /><br /><p></b>');
 
             // with tag balancing disabled
             var output = (new Purifier({enableTagBalancing:false})).purify(html);
-            assert.equal(output, "</div>foo</h2>bar<a href=\"123\">hello<b>world</a><embed />123</embed><br /><br /><p>");
+            assert.equal(output, '</div>foo</h2>bar<a href="123">hello<b>world</a><embed />123</embed><br /><br /><p>');
         });
 
         it('should handle all vectors mentioned in https://html5sec.org', function(){

--- a/tests/unit/html-purify.js
+++ b/tests/unit/html-purify.js
@@ -31,17 +31,30 @@ Authors: Aditya Mahendrakar <maditya@yahoo-inc.com>
             assert.equal(output, '<h1 id="foo" title="asd" checked>hello world 2</h1>');
         });
 
-        it('should always balance unopened tags', function(){
+        it('should balance tags', function(){
             var html = "</div>foo</h2>bar<a href=\"123\">hello<b>world</a><embed>123</embed><br /><br/><p>";
 
             // with tag balancing enabled by default
-            var output = (new Purifier({enableTagBalancing:true})).purify(html);
+            var output = (new Purifier({tagBalance:{enabled:true}})).purify(html);
             assert.equal(output, 'foobar<a href="123">hello<b>world</a><embed />123<br /><br /><p></b>');
+        });
+
+        it('should balance remaining tags and drop inputs when there are too many unclosed tags', function(){
+            var html = "<b>1<b>2<b>3<b>4<b>5<b>6</b></b></b></b>";
+
+            // with tag balancing enabled by default
+            var output = (new Purifier({tagBalance:{enabled:true, stackSize:3}})).purify(html);
+            assert.equal(output, '<b>1<b>2<b>3</b></b></b>');
+        });
+
+        it('should not balance tags if disabled', function(){
+            var html = "</div>foo</h2>bar<a href=\"123\">hello<b>world</a><embed>123</embed><br /><br/><p>";
 
             // with tag balancing disabled
-            var output = (new Purifier({enableTagBalancing:false})).purify(html);
+            var output = (new Purifier({tagBalance:{enabled:false}})).purify(html);
             assert.equal(output, '</div>foo</h2>bar<a href="123">hello<b>world</a><embed />123</embed><br /><br /><p>');
         });
+
 
         it('should handle all vectors mentioned in https://html5sec.org', function(){
 	    var output, i, vector;


### PR DESCRIPTION
**Changes**
- fix: optional tags are ignored during balancing, i.e., well-balanced input will not be broken by attempting to close optional tags.
- tag balancing logics simplified (accept closing tag as long as it exists in the stack)
- ignore self-closing solidus, which is required only for foreign elements
- added a cap to limit the max levels of unclosed/nested tags

**before the fix**
default x 0.64 ops/sec ±5.90% (6 runs sampled)
disabled tag balancing x 0.60 ops/sec ±3.82% (6 runs sampled)
Fastest is      [ 'default' ]
Speed/Time is   0.6423016849725829MB/s 1.5567777936666667s

**after the fix**
default x 0.72 ops/sec ±5.01% (6 runs sampled)
disabled tag balancing x 0.60 ops/sec ±3.91% (6 runs sampled)
Fastest is      [ 'default' ]
Speed/Time is   0.7190234217142741MB/s 1.3906654078333334s

it actually runs faster than without it using the given 1m file. so tag balancing doesn't seem to incur any significant performance hit.
