### PR TITLE
Fix require('html-purify') by using ./src/html-purify.js as main

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-mocha-istanbul": "^2.3.0"
   },
-  "main": "./bin/html-purify.js",
+  "main": "./src/html-purify.js",
   "bugs": {
     "url": "https://github.com/yahoo/html-purify/issues"
   },


### PR DESCRIPTION
Server side use (nodejs) does not work as described in the README.md:

``` js
/* create the html purifier */
var Purifier = require('html-purify');
var purifier = new Purifier();

var input = '...'; 
/* filter the input string */
var result = purifier.purify(input);
```

I verified this with the following steps:

``` js
npm install
npm run-script build
npm test
npm install . -g
cd ~
node
> var Purifier = require('html-purify');
Usage: html-purify <any html file>
```

With this pull request it behaves as documented:

``` js
> var Purifier = require('html-purify');
undefined
> new Purifier().purify('<a href="javascript:alert(1)">yahoo</a>')
'<a href="x-javascript:alert(1)">yahoo</a>'
```

As a workaround I currently require the src file directly in my application:

``` js
npm install git+https://git@github.com/yahoo/html-purify.git
var Purifier = require('../../node_modules/html-purify/src/html-purify');
```
